### PR TITLE
Updated gem spec to avoid bundle update error due to RC in version strin...

### DIFF
--- a/paranoia_uniqueness_validator.gemspec
+++ b/paranoia_uniqueness_validator.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "activerecord", "~> 4.0.0.rc1"
+  gem.add_dependency "activerecord", "~> 4.0.0"
 
   gem.add_development_dependency "paranoia"
-  gem.add_development_dependency "database_cleaner", "~> 1.0.0.RC1"
-  gem.add_development_dependency "rails", "~> 4.0.0.rc1"
+  gem.add_development_dependency "database_cleaner", "~> 1.2.0"
+  gem.add_development_dependency "rails", "~> 4.0.0"
   gem.add_development_dependency "rspec-rails"
 end


### PR DESCRIPTION
I am getting following error messages when using bundle install and bundle update:

"    paranoia_uniqueness_validator (= 1.0.0) ruby depends on
      activerecord (4.0.1.rc1)"

So I updated the gemspec a little bit to get rid of the RC from version number.
