### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this line to your application's Gemfile:
     gem 'paranoia_uniqueness_validator', '0.1.0'
 
     # Rails 4
-    gem 'paranoia_uniqueness_validator', '1.0.0'
+    gem 'paranoia_uniqueness_validator', '1.1.0'
 And then execute:
 
     $ bundle


### PR DESCRIPTION
Installing version 1.0.0 with ActiveRecord > 4.1 will create an error:

```ruby
Bundler could not find compatible versions for gem "activerecord":
  In snapshot (Gemfile.lock):
    activerecord (4.1.6)

  In Gemfile:
    paranoia_uniqueness_validator (= 1.0.0) ruby depends on
      activerecord (~> 4.0.0.rc1) ruby

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```