### PR TITLE
Fix method signature for _relation methods to support Rails 5.1

### DIFF
--- a/lib/paranoia_uniqueness_validator/validations/uniqueness_without_deleted.rb
+++ b/lib/paranoia_uniqueness_validator/validations/uniqueness_without_deleted.rb
@@ -3,10 +3,9 @@ module ParanoiaUniquenessValidator
     class UniquenessWithoutDeletedValidator < ActiveRecord::Validations::UniquenessValidator
       def validate_each(record, attribute, value)
         finder_class = find_finder_class_for(record)
-        table = finder_class.arel_table
         value = map_enum_attribute(finder_class, attribute, value)
 
-        relation = build_relation(finder_class, table, attribute, value)
+        relation = build_relation(finder_class, attribute, value)
         if record.persisted?
           if finder_class.primary_key
             relation = relation.where.not(finder_class.primary_key => record.id_was || record.id)
@@ -14,7 +13,7 @@ module ParanoiaUniquenessValidator
             raise UnknownPrimaryKey.new(finder_class, "Can not validate uniqueness for persisted record without primary key.")
           end
         end
-        relation = scope_relation(record, table, relation)
+        relation = scope_relation(record, relation)
         relation = relation.merge(options[:conditions]) if options[:conditions]
 
         if defined?('Paranoia') && Paranoia.respond_to?(:default_sentinel_value)

--- a/paranoia_uniqueness_validator.gemspec
+++ b/paranoia_uniqueness_validator.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "activerecord", ">= 5.0.0", "< 5.1"
+  gem.add_dependency "activerecord", ">= 5.0.0", "< 5.2"
 
   gem.add_development_dependency "paranoia"
   gem.add_development_dependency "database_cleaner"


### PR DESCRIPTION
The method signatures for the uniqueness validator's `scope_relation` and `build_relation` methods in Rails have been changed.

https://github.com/rails/rails/commit/f3cb1f8a597b3b30fdc7a39dcbe38b123a38144d

There are a couple of deprecation warnings for rails 5.1 still (from DatabaseCleaner and the `new_framework_defaults`), but this allows tests to pass.