### PR TITLE
Use `ActiveSupport.on_load` to hook into ActiveRecord

### DIFF
--- a/lib/paranoia_uniqueness_validator.rb
+++ b/lib/paranoia_uniqueness_validator.rb
@@ -5,6 +5,6 @@ module ParanoiaUniquenessValidator
 
 end
 
-class ActiveRecord::Base
+ActiveSupport.on_load(:active_record) do
   include ParanoiaUniquenessValidator::Validations
 end


### PR DESCRIPTION
Hooking into `ActiveRecord::Base` can cause issues with other configuration as it will autoload constants too soon.

See https://github.com/rails/rails/issues/23589 for details.

The recommended approach is to use `ActiveSupport.on_load`.

Here is the same fix in devise for reference - https://github.com/heartcombo/devise/commit/c2c74b0a39238e7d997486814a1c8f75fdaf276f